### PR TITLE
I was not able to build (at least on mac), and it turns out to be a #define issue

### DIFF
--- a/ext/ncurses/ncurses_wrap.h
+++ b/ext/ncurses/ncurses_wrap.h
@@ -73,6 +73,7 @@ int close(int);
 #endif
 
 #ifdef HAVE_NCURSES_H
+#define NCURSES_OPAQUE 0
 #  include <ncurses.h>
 #else
 #  ifdef HAVE_NCURSES_CURSES_H


### PR DESCRIPTION
Also I pushed it to rubygems.org, so that everyone can install it via 'gem install ncurses-ruby'.

Thanks for wrapping it as a gem.
