### PR TITLE
Make tclock example work on ruby 1.9

### DIFF
--- a/examples/tclock.rb
+++ b/examples/tclock.rb
@@ -48,7 +48,7 @@ end
 
 # Plot a point
 def plot(x, y, c)
-  Ncurses.mvaddch(y, x, c[0])
+  Ncurses.mvaddch(y, x, c[0].ord)
 end
 
 # Draw a diagonal(arbitrary) line using Bresenham's alogrithm.


### PR DESCRIPTION
Ruby 1.9 has String[Integer] return single character string, not ascii character code integer. With this change it works in both ruby 1.8 and 1.9.
