### PR TITLE
fix string literal in form_wrap.c so that ncurses.so will build

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -13,3 +13,4 @@ Simon Strandgaard
 Paul Duncan
 Tim Sutherland
 Earle Clubb
+Jeffrey Crowell (crowell at bu dot edu)

--- a/ext/ncurses/form_wrap.c
+++ b/ext/ncurses/form_wrap.c
@@ -1130,7 +1130,7 @@ static void* make_arg(va_list* ap) {
 		  char msg[500];
 		  snprintf(msg, 500, "The validation functions for this field type need %d additional arguments.",NUM2INT(argc)-1);
 		  msg[499]=0;
-		  rb_raise(rb_eArgError, msg);	
+		  rb_raise(rb_eArgError, "%s", msg);	
 		}
 	 } 
   }


### PR DESCRIPTION
the gem wouldn't build because of the following errors

```
{13-06-12 23:01}raxcity:~/ncurses-ruby/ext/ncurses@master✗✗✗✗✗✗ jeff# make
compiling menu_wrap.c
compiling form_wrap.c
form_wrap.c: In function 'make_arg':
form_wrap.c:1133:5: error: format not a string literal and no format arguments [-Werror=format-security]
cc1: some warnings being treated as errors
make: *** [form_wrap.o] Error 1
```

This patch makes the format a string literal with arguments, allowing it to build.
