### PR TITLE
Fixes the following compiler error:

### DIFF
--- a/ext/ncurses/ncurses_wrap.h
+++ b/ext/ncurses/ncurses_wrap.h
@@ -84,6 +84,7 @@ int close(int);
 #endif
 
 #include <ruby.h>
+#include <sys/time.h>
 
 extern VALUE mNcurses;  /* module Ncurses */
 extern VALUE cWINDOW;   /* class Ncurses::WINDOW */


### PR DESCRIPTION
ext/ncurses/ncurses_wrap.c: In function ‘rbncurshelper_nonblocking_wgetch’:
ext/ncurses/ncurses_wrap.c:807:12: error: variable ‘tz’ has initializer but incomplete type
       struct timezone tz = {0,0};

Also closes #6
