### PR TITLE
The upgrade to XCODE 5.1 introduced an extra bug where the clang flag

### DIFF
--- a/ext/ncurses/extconf.rb
+++ b/ext/ncurses/extconf.rb
@@ -27,7 +27,12 @@ $CXXFLAGS  = $CFLAGS
 
 # Add paths for NetBSD.
 $CFLAGS  += " -I/usr/pkg/include"
-$LDFLAGS += " -L/usr/pkg/lib"
+if (/darwin/ =~ RUBY_PLATFORM) != nil
+  $LDFLAGS = ""
+  $DLDFLAGS = "-undefineddynamic_lookup"
+else
+  $LDFLAGS += " -L/usr/pkg/lib"
+end
 
 have_header("unistd.h")
 if have_header("ncurses.h")


### PR DESCRIPTION
-multiply_definedsuppress was removed and will no longer be supported.
Due to not being able to compile on my linux computer at the moment I
have included the change to DLDFLAGS in the logic to detect if the user
is compiling on a Mac OS. The following is the error generated without
the DLDFLAGS:

```
clang: error: unknown argument: '-multiply_definedsuppress'
[-Wunused-command-line-argument-hard-error-in-future]
clang: note: this will be a hard error (cannot be downgraded to a
warning) in the future
```

The other bugs this fixes is the inability to compile since Mac OS does
not have a /usr/pkg/lib directory.

That is all.
